### PR TITLE
Add documentation on curators

### DIFF
--- a/docs/documentation/contribute.md
+++ b/docs/documentation/contribute.md
@@ -4,7 +4,7 @@
 
 **Hi there!** :wave: :blush:
 
-RiverBench is an open, community-driven project, so you are more than welcome to contribute. This page explains how to do it.
+RiverBench is an open, [community-driven](maintainers.md) project, so you are more than welcome to contribute. This page explains how to do it.
 
 ## Reporting benchmark results
 
@@ -16,7 +16,7 @@ If you have run a benchmark using RiverBench's datasets or tasks, **we highly en
 
 Do you have an interesting RDF dataset that would make a good addition to RiverBench? Great!
 
-Have a look at the **[dedicated guide on creating new datasets](creating-new-dataset.md)** which also explains the requirements for new datasets. If you still have questions, don't hesitate to contact RiverBench's maintainer by [opening an issue on GitHub](https://github.com/RiverBench/RiverBench/issues/new/choose).
+Have a look at the **[dedicated guide on creating new datasets](creating-new-dataset.md)** which also explains the requirements for new datasets. If you still have questions, don't hesitate to contact RiverBench's maintainers by [opening an issue on GitHub](https://github.com/RiverBench/RiverBench/issues/new/choose).
 
 <div style="text-align: center" markdown>[:material-database-plus: Propose a new dataset](creating-new-dataset.md){ .md-button }</div>
 
@@ -49,8 +49,9 @@ You are welcome to submit any pull requests to these repositories. If you are un
 
 ## Deeper changes
 
-Do you see a glaring issue with the way RiverBench is organized? Or maybe you have a great idea for a new feature? Please contact the maintainer directly: [Piotr Sowiński (Ostrzyciel)](https://github.com/Ostrzyciel) by following the contact info on his profile page. **We are open to any collaboration.**
+Do you see a glaring issue with the way RiverBench is organized? Or maybe you have a great idea for a new feature? You can either [open an issue](https://github.com/RiverBench/RiverBench/issues/new/choose) or contact the maintainers directly: [RiverBench maintainers](maintainers.md).
 
 ## See also
 
 - [Using RiverBench – quick start guide](using.md)
+- [RiverBench maintainers](maintainers.md)

--- a/docs/documentation/creating-new-dataset.md
+++ b/docs/documentation/creating-new-dataset.md
@@ -23,11 +23,11 @@ Fill in the fields with the required information, using the instructions embedde
 
 !!! note
 
-    If you have trouble filling in any of the fields, you can leave them blank and ask the maintainer for help.
+    If you have trouble filling in any of the fields, you can leave them blank and ask [a maintainer](maintainers.md) for help.
 
 ## Step 2: Wait for approval
 
-An administrator will be notified your request and will review the form and the dataset. The administrator may ask for additional information or clarifications. Once reviewed, the admin will create a new repository for you and give you access to it.
+[RiverBench curators](maintainers.md) will be notified your request and will review the form and the dataset. The maintainers may ask for additional information or clarifications. Once reviewed, a technical administrator will create a new repository for you and give you access to it.
 
 ## Step 3: Upload the dataset sources
 
@@ -51,13 +51,20 @@ An administrator will be notified your request and will review the form and the 
     - For `dcat:theme` use concepts from the [EuroVoc thesaurus](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://eurovoc.europa.eu/100141). Use only elements of type "Concept" (without a number in their name), not "Concept scheme" or "Domain concept".
 3. Open the `LICENSE` file and replace the placeholder text with the license of the dataset. You can find commonly used templates [here](https://github.com/licenses/license-templates/tree/master/templates).
 4. Save your changes and commit to the main branch.
-5. Inform the administrator in your issue that you have completed the metadata for your dataset. The admin will then finalize adding the dataset to the suite and provide any necessary assistance.
+5. Post a comment in your issue saying that you have completed the metadata for your dataset. The technical administrator will then finalize adding the dataset to the suite and provide any necessary assistance.
 
 ----
 
-## Instructions for admins
+## Instructions for maintainers
 
-- Review the issue template – make sure all required information is provided.
+### Reviewing the proposal
+
+- Review the issue template – make sure all required information is provided and that it's clear.
+- Check if the dataset meets the [requirements](#step-0-check-the-requirements).
+    - Deciding whether or not the dataset should be in RiverBench is up to you. Is there a need for it? Will it make the benchmarks more diverse and representative? Does it cover a new use case?
+
+### Technical: setting up the dataset
+
 - [Create a new repository](https://github.com/organizations/RiverBench/repositories/new) for the dataset with name `dataset-[IDENTIFIER]`. In the repository settings:
   - Use the `RiverBench/dataset-template` repository as the template.
   - Mark the repo as public.

--- a/docs/documentation/creating-new-task.md
+++ b/docs/documentation/creating-new-task.md
@@ -18,7 +18,7 @@ Fill in the fields with the required information, using the instructions embedde
 
 !!! note
 
-    If you have trouble filling in any of the fields, you can leave them blank and ask the maintainer for help.
+    If you have trouble filling in any of the fields, you can leave them blank and ask [a maintainer](maintainers.md) for help.
 
 !!! question "Does your task require more than just RDF data? SPARQL, anyone?"
 
@@ -26,7 +26,7 @@ Fill in the fields with the required information, using the instructions embedde
 
 ## Step 2: Wait for approval
 
-An administrator will be notified your request and will review the form and the task description. The administrator may ask for additional information or clarifications.
+[RiverBench curators](maintainers.md) will be notified your request and will review the form and the task description. The curators may ask for additional information or clarifications.
 
 ## Step 3: Create a pull request
 

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -11,6 +11,7 @@ This documentation explains how to use and contribute to RiverBench.
     - [Metadata of datasets, profiles, and more](metadata.md)
     - [Versioning and releases](versioning.md)
     - [Licensing and citation](licensing.md)
+    - [RiverBench maintainers](maintainers.md)
 - **For contributors**
     - **[How to contribute?](contribute.md)**
     - [Reporting benchmark results](reporting-results.md)

--- a/docs/documentation/licensing.md
+++ b/docs/documentation/licensing.md
@@ -37,9 +37,9 @@ If you use the individual datasets, if possible you should at least cite the lin
 
 Remember to specify the stable version of RiverBench that you used. Using the "dev" version is not recommended, as it can change at any time. See also: [Versioning and releases](versioning.md).
 
-## RiverBench maintainer
+## RiverBench maintainers
 
-RiverBench was created and is maintained by [Piotr Sowiński (Ostrzyciel)](https://ostrzyciel.eu) – [GitHub](https://github.com/Ostrzyciel).
+See: **[RiverBench maintainers](maintainers.md)**.
 
 ## All papers about RiverBench
 
@@ -79,3 +79,4 @@ In reverse chronological order:
 ## See also
 
 - [How to contribute?](contribute.md)
+- [Riverbench maintainers and curators](maintainers.md)

--- a/docs/documentation/maintainers.md
+++ b/docs/documentation/maintainers.md
@@ -1,0 +1,29 @@
+{{ top_buttons() }}
+
+# RiverBench maintainers
+
+**RiverBench is a community-owned project**, maintained and curated by volunteers.
+
+## Curators
+
+**Curators** are people experienced with RDF benchmarks who review proposals for [new datasets](creating-new-dataset.md) and [benchmark tasks](creating-new-task.md). They also have the deciding voice in other proposals and discussions about RiverBench (e.g., changes to the suite's structure or the addition of new features).
+
+Curators do not have any strict obligations to RiverBench – all work is done on a purely voluntary basis.
+
+New curators may be appointed with a consensus of the existing curators. If you are interested in becoming a curator, please contact any of them.
+
+### Current list of RiverBench curators
+
+In alphabetical order:
+
+- [Jean-Paul Calbimonte](https://jeanpi.org/), University of Applied Sciences and Arts Western Switzerland (HES-SO), Switzerland. [:octicons-mark-github-16: jpcik](https://github.com/jpcik)
+- [Piotr Sowiński](https://ostrzyciel.eu), Warsaw University of Technology, Poland. [:octicons-mark-github-16: Ostrzyciel](https://github.com/Ostrzyciel)
+
+## Technical administrators
+
+**Technical administrator** are responsible for the day-to-day operation of the RiverBench project. They manage the repositories, CI/CD pipelines, and documentation. The current technical administrator is [Piotr Sowiński (Ostrzyciel)](https://ostrzyciel.eu) – [GitHub](https://github.com/Ostrzyciel).
+
+## See also
+
+- [How to contribute?](contribute.md)
+- [Licensing and citation](licensing.md)

--- a/docs/documentation/versioning.md
+++ b/docs/documentation/versioning.md
@@ -21,7 +21,7 @@ The `dev` version of each dataset is its latest development version, correspondi
 
 To make a release:
 
-1. Read the above versioning rules and decide which version number to use. If you are unsure, [ask the suite's maintainer for help](https://github.com/RiverBench/RiverBench/issues/new/choose).
+1. Read the above versioning rules and decide which version number to use. If you are unsure, [ask the suite's technical administrator for help](maintainers.md).
 2. Go to your dataset's repository and check out the `main` branch on your local machine.
 3. Update the main branch by running `git pull`. Make sure the pull was successful.
 4. Create a new tag with the version number you decided on: `git tag vX.Y.Z`.


### PR DESCRIPTION
- Added a new page explaining who maintains RiverBench
- Explained briefly who are curators
- Added the list of curators with the first 2 people
- Updated the docs to point to curators in cases related to benchmarks themselves, and the technical admins for the technical stuff.

Issue: https://github.com/RiverBench/RiverBench/issues/135